### PR TITLE
fix typo & compiler warning (empty statement after if)

### DIFF
--- a/Chapter_3/BasicDataTypes/BasicDataTypes/Program.cs
+++ b/Chapter_3/BasicDataTypes/BasicDataTypes/Program.cs
@@ -144,7 +144,7 @@ namespace BasicDataTypes
     static void ParseFromStringsWithTryParse()
     {
       Console.WriteLine("=> Data type parsing with TryParse:");
-      if (bool.TryParse("True", out bool b)) ;
+      if (bool.TryParse("True", out bool b))
       {
         Console.WriteLine("Value of b: {0}", b);
       }


### PR DESCRIPTION
An unnecessary semicolon is present after the if statement, causing a compiler warning.